### PR TITLE
HD-914 fix memalign issue

### DIFF
--- a/memalign.go
+++ b/memalign.go
@@ -24,5 +24,6 @@ func memalign(n int, align int) ([]byte, error) {
 		// Success
 		return buf[:n], nil
 	}
+	offSet = align - offSet
 	return buf[offSet : offSet+n], nil
 }

--- a/memalign_test.go
+++ b/memalign_test.go
@@ -1,0 +1,18 @@
+package erasurecode
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemalign(t *testing.T) {
+	for i := 1; i < 16; i++ {
+		align := 1 << i
+		fmt.Println(align)
+		ptr, err := memalign(1000, int(align))
+		assert.NoError(t, err)
+		assert.Zero(t, getAlignDifference(ptr, align))
+	}
+}


### PR DESCRIPTION
Note: allocs are aligned on 8 by go. So an alloc by 16 will have a
difference of either 0 or 8. This does not change anything in the
running code