### PR TITLE
HD-3988: range matrix less io

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -891,7 +891,7 @@ func (backend *Backend) LinearizeMatrix(frags []ValidatedFragment, pieceSize int
 	for i := 0; i < nrChunks; i++ {
 		// launch goroutines, providing them a subrange of the final buffer so it can be used
 		// in concurrency without need to lock it access
-		func(chunkIdx int) {
+		go func(chunkIdx int) {
 			cDataFrags := C.makeStrArray(C.int(len(fragsIndex)))
 			// prepare the C array of pointer, respecting the offset in each fragments
 

--- a/backend.go
+++ b/backend.go
@@ -820,6 +820,24 @@ func (backend *Backend) ValidateFragmentMatrix(frag RawFragment, pieceSize int) 
 	return true
 }
 
+type ChunkInfo struct {
+	ChunkSize int
+	NrChunk   int
+}
+
+func (backend *Backend) ChunkInfo(fragRangeLen int, pieceSize int) ChunkInfo {
+	chunkSize := pieceSize + backend.headerSize
+	nrChunks := fragRangeLen / chunkSize
+	if nrChunks*chunkSize != fragRangeLen {
+		nrChunks++
+	}
+
+	return ChunkInfo{
+		ChunkSize: chunkSize,
+		NrChunk:   nrChunks,
+	}
+}
+
 func (backend *Backend) LinearizeMatrix(frags []ValidatedFragment, pieceSize int) (*DecodeData, error) {
 	var wg sync.WaitGroup
 
@@ -828,11 +846,7 @@ func (backend *Backend) LinearizeMatrix(frags []ValidatedFragment, pieceSize int
 	}
 
 	fragRangeLen := len(frags[0])
-	chunkSize := pieceSize + backend.headerSize
-	nrChunks := fragRangeLen / chunkSize
-	if nrChunks*chunkSize != fragRangeLen {
-		nrChunks++
-	}
+	chunkInfo := backend.ChunkInfo(fragRangeLen, pieceSize)
 
 	/* Fragments are sorted beforehand with the index of the first chunk.
 	   All chunks of a fragments share the same index. */
@@ -883,12 +897,12 @@ func (backend *Backend) LinearizeMatrix(frags []ValidatedFragment, pieceSize int
 	}
 	fragsIndex = fragsIndex[:lastDataFragIdxExcl]
 
-	dataB, data := backend.pool.New(nrChunks * pieceSize * len(fragsIndex))
+	dataB, data := backend.pool.New(chunkInfo.NrChunk * pieceSize * len(fragsIndex))
 	errorNb := uint32(0)
 	totLen := uint64(0)
-	wg.Add(nrChunks)
+	wg.Add(chunkInfo.NrChunk)
 
-	for i := 0; i < nrChunks; i++ {
+	for i := 0; i < chunkInfo.NrChunk; i++ {
 		// launch goroutines, providing them a subrange of the final buffer so it can be used
 		// in concurrency without need to lock it access
 		go func(chunkIdx int) {
@@ -897,7 +911,7 @@ func (backend *Backend) LinearizeMatrix(frags []ValidatedFragment, pieceSize int
 
 			for i, idx := range fragsIndex {
 				frag := frags[idx]
-				cSetArrayItem(cDataFrags, i, (*C.char)(unsafe.Pointer(&frag[chunkIdx*chunkSize])))
+				cSetArrayItem(cDataFrags, i, (*C.char)(unsafe.Pointer(&frag[chunkIdx*chunkInfo.ChunkSize])))
 			}
 			// try to decode fastly (if we have all data fragments), providing the good offset of the
 			// linearized buffer, according the block number we are decoding
@@ -933,25 +947,25 @@ func (backend *Backend) LinearizeMatrix(frags []ValidatedFragment, pieceSize int
 
 // DecodeMatrix tries to reconstruct the data fragments and returns the linearized data.
 func (backend *Backend) DecodeMatrix(frags []ValidatedFragment, pieceSize int) (*DecodeData, error) {
-	fragRangeLen := len(frags[0])
-	chunkSize := pieceSize + backend.headerSize
-	chunkNr := fragRangeLen / chunkSize
-	if chunkNr*chunkSize != fragRangeLen {
-		chunkNr++
+	if len(frags) == 0 {
+		return nil, errors.New("Decoding requires at least one fragment")
 	}
 
-	dataB, data := backend.pool.New(chunkNr * pieceSize * backend.K)
+	fragRangeLen := len(frags[0])
+	chunkInfo := backend.ChunkInfo(fragRangeLen, pieceSize)
+
+	dataB, data := backend.pool.New(chunkInfo.NrChunk * pieceSize * backend.K)
 
 	var totLen int64
 
-	for i := 0; i < chunkNr; i++ {
+	for i := 0; i < chunkInfo.NrChunk; i++ {
 		vect := make([][]byte, len(frags))
 		for j := 0; j < len(frags); j++ {
 			if len(frags[j]) != fragRangeLen {
 				return nil, errors.New("invalid fragment len")
 			}
 
-			vect[j] = frags[j][i*chunkSize : (i+1)*chunkSize]
+			vect[j] = frags[j][i*chunkInfo.ChunkSize : (i+1)*chunkInfo.ChunkSize]
 		}
 		subdata, err := backend.Decode(vect)
 		if err != nil {

--- a/backend.go
+++ b/backend.go
@@ -961,48 +961,129 @@ func (backend *Backend) DecodeMatrix(frags []ValidatedFragment, pieceSize int) (
 		totLen += int64(len(subdata.Data))
 		subdata.Free()
 	}
+
 	return &DecodeData{data[:totLen:totLen], func() {
 		backend.pool.Release(dataB)
 	}}, nil
 }
 
-// RangeMatrix describes informations needed to decode a range of encoded frags
+// RangeMatrix describes information needed to decode a range of encoded frags
 type RangeMatrix struct {
-	FragRangeStart    int // Start offset in each K+M fragments
-	FragRangeEnd      int // End offset in each K+M fragments
-	DecodedRangeStart int // Start offset in decoded data
-	DecodedRangeEnd   int // end offset in decoded data
+	ReqStartIncl int
+	ReqEndIncl   int
+
+	/* The fragments that the range spans.  */
+	FragFirstIncl int
+	FragCount     int
+
+	/* The range in each fragment to be queried satisfy the requested range. */
+	InFragRangeStartIncl int
+	InFragRangeEndExcl   int
+
+	/* The requested range relative to the decoded buffer. */
+	LinearizedRangeStartIncl int
+	DecodedRangeStartIncl    int
 }
 
-// GetRangeMatrix returns the bounds of each data fragments to get to satisfy
-// {start, end} range
-func (backend *Backend) GetRangeMatrix(start, end, chunksize, fragSize int) *RangeMatrix {
-	blockSize := chunksize
-	groupSize := blockSize * backend.K
+/*
+ * Returns the ranges to read a matrix encoded data. This function tries
+ * to minimize the number of request to perform depending on the requested
+ * range.
+ *
+ * There are a few design choices that make the result not always obvious.
+ * 		1. Each fragment range is always identical.
+ *      2. When the requested range wraps around fragments all fragments
+ *         are always queried.
+ *
+ * (1) is currently necessary to avoid querying multiple time the same
+ * fragment in case of failures (to reconstruct the data). This prefer
+ * performing the minimum amount of IO requests, instead of reading the minimum
+ * amount of data. We could lift this constraint if the caller would stream
+ * group at a time but that would require the backend to have matching
+ * alignement constraints.
+ *
+ * (2) could also be lifted. This is currently done to avoid changing the way
+ * the current decoding is performed. To work, it currently requires consecutive
+ * fragments. We then can't leave gaps in fragments. For example if
+ * we take a erasure code with 4 data fragments of 4 chunks,
+ * with the requested range represented by a '*' and the resulting fragment
+ * ranges by '[]':
+ *
+ *     p1 [-[- *]-]    The request here start at the end of the 2nd chunk in p4
+ *        [-[- *]-]    then wraps around in the subsequent chunks in p1 and p2.
+ *     .. [-[- -]-]
+ *     p4 [-[* -]-]    When this occurs, we will still query, p4 just to decode
+ *                     the relevant requested range. The decoded buffer
+ *                     will look like [p1 p2 p3 p4(*) p1(*) p2(*) p3 p4].
+ *                     Chunks not marked with a '*' are discarded. Note how
+ *                     the heading and trailing is unecessary and could be
+ *                     discarded in the ideal case.
+ *
+ * Perfect cases occur when the request span a single group (column):
+ *
+ *     p1 [- - - -]
+ * 		  [-[*]- -]
+ *     .. [-[*]- -]
+ *     p4 [-[*]- -]
+ *
+ */
+func (backend *Backend) GetRangeMatrix(startIncl, endIncl, pieceSize, fragSize int) *RangeMatrix {
+	chunkSize := pieceSize + backend.headerSize
+	groupSize := pieceSize * backend.K
 
-	// check that range can be satisfied
-	nrChunkByFrag := fragSize / (backend.headerSize + chunksize)
-	trueFragLen := nrChunkByFrag * chunksize
-	linearizedDataLen := trueFragLen * backend.K
-
-	if start > linearizedDataLen || end > linearizedDataLen || start > end {
+	/* At this point we don't know what is the true payload size, but we
+	   can at least check that it doesn't exceed the maximum payload that
+	   this configuration can handle. */
+	nrChunkByFrag := fragSize / chunkSize
+	dataLenPerFrag := fragSize - nrChunkByFrag*backend.headerSize
+	maxDataLen := dataLenPerFrag * backend.K
+	if startIncl >= maxDataLen || endIncl >= maxDataLen || startIncl > endIncl {
 		return nil
 	}
 
-	// start's block number
-	rStart := start / groupSize
-	rEnd := end / groupSize
+	pieceStartIncl := startIncl / pieceSize
+	pieceEndIncl := endIncl / pieceSize
 
-	// convert block number to offset
-	fragStart := rStart * (chunksize + backend.headerSize)
-	fragEnd := (rEnd + 1) * (chunksize + backend.headerSize)
-	linearizedStart := rStart * backend.K * chunksize
+	groupStartIncl := pieceStartIncl / backend.K
+	groupEndIncl := pieceEndIncl / backend.K
+
+	fragFirstIncl := pieceStartIncl % backend.K
+	fragCount := (pieceEndIncl + 1 - pieceStartIncl)
+	dataOffset := pieceStartIncl * pieceSize
+
+	/* When wrapping around, we read the full groups. */
+	if fragFirstIncl+fragCount > backend.K {
+		fragFirstIncl = 0
+		fragCount = backend.K
+		dataOffset = groupStartIncl * groupSize
+	}
+
+	/* For each fragment, this is the minimum range to read -- including
+	   the header -- to decode or repair the data. */
+	inFragRangeStartIncl := groupStartIncl * chunkSize
+	inFragRangeEndExcl := (groupEndIncl + 1) * chunkSize
+
+	/* The output buffer only contains the data necessary to read the range,
+	   and the requested range must be adjusted to be relative
+	   to the output buffer which starts at 0.
+
+	   Special care is needed whe the requested range wraps in the
+	   fragments. In that case we degenerate to querying all groups of
+	   all fragments (see (2) in the function's comment above). */
+	linearizedRangeStartIncl := startIncl - dataOffset
+
+	/* Decoding always works on a group boundary. */
+	decodedRangeStartIncl := startIncl - groupStartIncl*groupSize
 
 	return &RangeMatrix{
-		FragRangeStart:    fragStart,
-		FragRangeEnd:      fragEnd,
-		DecodedRangeStart: start - linearizedStart,
-		DecodedRangeEnd:   end - linearizedStart,
+		ReqStartIncl:             startIncl,
+		ReqEndIncl:               endIncl,
+		FragFirstIncl:            fragFirstIncl,
+		FragCount:                fragCount,
+		InFragRangeStartIncl:     inFragRangeStartIncl,
+		InFragRangeEndExcl:       inFragRangeEndExcl,
+		DecodedRangeStartIncl:    decodedRangeStartIncl,
+		LinearizedRangeStartIncl: linearizedRangeStartIncl,
 	}
 }
 

--- a/backend.go
+++ b/backend.go
@@ -963,17 +963,19 @@ func (backend *Backend) DecodeMatrix(frags []ValidatedFragment, pieceSize int) (
 
 	dataB, data := backend.pool.New(chunkInfo.NrChunk * pieceSize * backend.K)
 
-	var totLen int64
+	for i := range frags {
+		if len(frags[i]) != fragRangeLen {
+			return nil, errors.New("invalid fragment len")
+		}
+	}
 
+	var totLen int64
 	for i := 0; i < chunkInfo.NrChunk; i++ {
 		vect := make([][]byte, len(frags))
-		for j := 0; j < len(frags); j++ {
-			if len(frags[j]) != fragRangeLen {
-				return nil, errors.New("invalid fragment len")
-			}
-
+		for j := range frags {
 			vect[j] = frags[j][i*chunkInfo.ChunkSize : (i+1)*chunkInfo.ChunkSize]
 		}
+
 		subdata, err := backend.Decode(vect)
 		if err != nil {
 			return nil, fmt.Errorf("error subdecoding %d cause =%v", i, err)

--- a/backend.go
+++ b/backend.go
@@ -18,64 +18,53 @@ ec_backend_id_t getBackendID(struct fragment_header_s *header) { return header->
 uint32_t getECVersion(struct fragment_header_s *header) { return header->libec_version; }
 int getHeaderSize() { return sizeof(struct fragment_header_s); }
 
-// decode_fast is used when we have all data fragment. Instead of doing a true decoding, we just
+// linearize is used when we have all data fragment. Instead of doing a true decoding, we just
 // reassemble all the fragment linearized in a buffer. This is mainly a copy of liberasurecode
 // fragment_to_string function, except that we won't do any addionnal allocation
-// 'k' is the number of expected data fragment
-// 'in' is an array of all frags
+//
+// /!\ This function does not perform any header checksum validation.
+// If fragments must be validated checks 'check_matrix_fragment'
+//
+// 'k' the number of data fragment used for the encoding.
+// 'in' is an array of all data frags, in their index order.
 // 'inlen' is the array size
 // 'dest' is an already allocated buffer where data will be linearized
 // 'destlen' is the buffer size, and hence, the maximum number of bytes linearized
 // 'outlen' is a pointer containing the number of bytes really linearized in dest (always lower or equal to destlen)
 // it returns dest if nothing went wrong, else null
-char* decode_fast(int k, char **in, int inlen, char *dest, uint64_t destlen, uint64_t *outlen) {
+char* linearize(int k, char **in, int inlen, char *dest, uint64_t destlen, uint64_t *outlen) {
     int i;
     int curr_idx = 0;
     int orig_data_size = -1;
-    char *frags[k];
-    // cannot decode fastly
-    if (inlen < k) {
-        return NULL;
-    }
+
     if (dest == NULL || outlen == NULL) {
         return NULL;
     }
-    memset(frags, 0, sizeof(frags));
 
-    // we start by iterating on all fragment, and ordering according to the fragment index
-    // in the header all data fragment (fragment whose index is lower than k)
-    for (i = 0; i < inlen && curr_idx != k; i++) {
-        int index;
-        int data_size;
-        if (is_invalid_fragment_header((fragment_header_t*)in[i])) {
-            continue;
-        }
-        index = get_fragment_idx(in[i]);
-        data_size = get_fragment_payload_size(in[i]);
-        if (index < 0 || data_size < 0) {
-            continue;
-        }
+    // The following perform small correctness checks before linearizing
+    // the buffer
+    int previous_idx = -1;
+    for (i = 0; i < inlen; i++) {
+        int index = get_fragment_idx(in[i]);
+
         if (orig_data_size < 0) {
             orig_data_size = get_orig_data_size(in[i]);
         } else if(get_orig_data_size(in[i]) != orig_data_size) {
-            continue;
+            return NULL;
         }
+
         if (index >= k) {
-            continue;
+            return NULL;
         }
-        if (frags[index] == NULL) {
-            curr_idx ++;
-            frags[index] = in[i];
+
+        // Checks that the fragments are sorted.
+        if (previous_idx > index) {
+            return NULL;
         }
+        previous_idx = index;
     }
 
-    // if we don't have enough data fragment, we leave this function and will probably
-    // fallback on a true decoding function
-    if (curr_idx != k) {
-        return NULL;
-    }
-
-    // compute how number of bytes will be linearized
+    // compute the number of bytes needed for the output
     int tocopy = orig_data_size;
     int string_off = 0;
     *outlen = orig_data_size;
@@ -85,15 +74,33 @@ char* decode_fast(int k, char **in, int inlen, char *dest, uint64_t destlen, uin
     }
 
     // copy in an ordered way all bytes of fragments in the buffer
-    for (i = 0; i < k && tocopy > 0; i++) {
-        char *f = get_data_ptr_from_fragment(frags[i]);
-        int fsize = get_fragment_payload_size(frags[i]);
+    for (i = 0; i < inlen && tocopy > 0; i++) {
+        char *f = get_data_ptr_from_fragment(in[i]);
+        int fsize = get_fragment_payload_size(in[i]);
         int psize = tocopy > fsize ? fsize : tocopy;
         memcpy(dest + string_off, f, psize);
         tocopy -= psize;
         string_off += psize;
     }
     return dest;
+}
+
+bool check_matrix_fragment(char *frag, int frag_len, int piecesize) {
+    size_t offset = 0;
+
+    bool aligned = (frag_len % (piecesize + getHeaderSize())) == 0;
+    if (!aligned) {
+        return false;
+    }
+
+    while (offset < frag_len) {
+        if (is_invalid_fragment_header((fragment_header_t*)&frag[offset])) {
+            return false;
+        }
+        offset += piecesize + getHeaderSize();
+    }
+
+    return true;
 }
 
 
@@ -410,6 +417,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -800,50 +808,110 @@ type DecodeData struct {
 // 	}
 // }
 
-// DecodeMatrix decode all the subchunk of frags, and linearize data
-func (backend *Backend) DecodeMatrix(frags [][]byte, piecesize int) (*DecodeData, error) {
+type RawFragment = []byte
+type ValidatedFragment = []byte
+
+func (backend *Backend) ValidateFragmentMatrix(frag RawFragment, pieceSize int) bool {
+	result := C.check_matrix_fragment((*C.char)(unsafe.Pointer(&frag[0])), C.int(len(frag)), C.int(pieceSize))
+	if result != C.bool(true) {
+		return false
+	}
+
+	return true
+}
+
+func (backend *Backend) LinearizeMatrix(frags []ValidatedFragment, pieceSize int) (*DecodeData, error) {
 	var wg sync.WaitGroup
 
 	if len(frags) == 0 {
-		return nil, errors.New("decoding requires at least one fragment")
+		return nil, errors.New("linearizing requires at least one fragment")
 	}
 
-	fragLen := len(frags[0])
-	lenBlock := piecesize + backend.headerSize
-	numBlock := fragLen / lenBlock
-	if numBlock*lenBlock != fragLen {
-		numBlock++
+	fragRangeLen := len(frags[0])
+	chunkSize := pieceSize + backend.headerSize
+	nrChunks := fragRangeLen / chunkSize
+	if nrChunks*chunkSize != fragRangeLen {
+		nrChunks++
 	}
 
-	// allocate output buffer
-	dataB, data := backend.pool.New(numBlock * piecesize * backend.K)
+	/* Fragments are sorted beforehand with the index of the first chunk.
+	   All chunks of a fragments share the same index. */
+	fragsIndex := make([]int, len(frags))
+	for i := 0; i < len(frags); i += 1 {
+		fragsIndex[i] = i
+	}
 
+	sort.Slice(fragsIndex, func(i, j int) bool {
+		lhs := frags[fragsIndex[i]]
+		rhs := frags[fragsIndex[j]]
+
+		var lhsIdx, rhsIdx C.int
+		lhsIdx = C.get_fragment_idx((*C.char)(unsafe.Pointer(&lhs[0])))
+		rhsIdx = C.get_fragment_idx((*C.char)(unsafe.Pointer(&rhs[0])))
+
+		return lhsIdx < rhsIdx
+	})
+
+	/* There is no reconstruction that can happen.
+	   All coding fragments must be ignored */
+	lastDataFragIdxExcl := 0
+	previousFragIdx := -1
+	for lastDataFragIdxExcl < len(fragsIndex) {
+		frag := frags[fragsIndex[lastDataFragIdxExcl]]
+		idx := int(C.get_fragment_idx((*C.char)(unsafe.Pointer(&frag[0]))))
+
+		if idx < 0 {
+			return nil, errors.New("invalid fragment index")
+		}
+
+		if idx >= backend.K {
+			break
+		}
+
+		if len(frags[0]) != fragRangeLen {
+			return nil, errors.New("invalid fragment len")
+		}
+
+		if previousFragIdx > 0 && (idx-previousFragIdx) != 1 {
+			/* Fragments are not contiguous. This functions doesn't supports
+			   gaps. */
+			return nil, errors.New("gaps in the provided fragments")
+		}
+
+		lastDataFragIdxExcl += 1
+		previousFragIdx = idx
+	}
+	fragsIndex = fragsIndex[:lastDataFragIdxExcl]
+
+	dataB, data := backend.pool.New(nrChunks * pieceSize * len(fragsIndex))
 	errorNb := uint32(0)
 	totLen := uint64(0)
-	wg.Add(numBlock)
+	wg.Add(nrChunks)
 
-	for i := 0; i < numBlock; i++ {
+	for i := 0; i < nrChunks; i++ {
 		// launch goroutines, providing them a subrange of the final buffer so it can be used
 		// in concurrency without need to lock it access
-		go func(blockNr int) {
-			cFrags := C.makeStrArray(C.int(len(frags)))
+		func(chunkIdx int) {
+			cDataFrags := C.makeStrArray(C.int(len(fragsIndex)))
 			// prepare the C array of pointer, respecting the offset in each fragments
-			for index, frags := range frags {
-				cSetArrayItem(cFrags, index, (*C.char)(unsafe.Pointer(&frags[blockNr*lenBlock])))
+
+			for i, idx := range fragsIndex {
+				frag := frags[idx]
+				cSetArrayItem(cDataFrags, i, (*C.char)(unsafe.Pointer(&frag[chunkIdx*chunkSize])))
 			}
 			// try to decode fastly (if we have all data fragments), providing the good offset of the
 			// linearized buffer, according the block number we are decoding
 			var outlen C.uint64_t
-			p := C.decode_fast(C.int(backend.K), cFrags, C.int(len(frags)),
-				(*C.char)(unsafe.Pointer(&data[blockNr*piecesize*backend.K])),
-				C.uint64_t(piecesize*backend.K), &outlen)
+			p := C.linearize(C.int(backend.K), cDataFrags, C.int(len(fragsIndex)),
+				(*C.char)(unsafe.Pointer(&data[chunkIdx*pieceSize*len(fragsIndex)])),
+				C.uint64_t(pieceSize*backend.K), &outlen)
 
 			if p == nil {
 				atomic.AddUint32(&errorNb, 1)
 			} else {
 				atomic.AddUint64(&totLen, uint64(outlen))
 			}
-			C.freeStrArray(cFrags)
+			C.freeStrArray(cDataFrags)
 			wg.Done()
 		}(i)
 	}
@@ -853,38 +921,37 @@ func (backend *Backend) DecodeMatrix(frags [][]byte, piecesize int) (*DecodeData
 	if errorNb != 0 {
 		// Release the previous buffer
 		backend.pool.Release(dataB)
-		return backend.decodeMatrixSlow(frags, piecesize)
+		return nil, errors.New("failed to linearize fragments")
 	}
 
-	// return our linearized data. Closure expect to free the C allocated data once
-	// the DecodeData.Data will not be used anymore
-	return &DecodeData{data[:totLen:totLen],
-			func() {
-				backend.pool.Release(dataB)
-			}},
-		nil
-
+	return &DecodeData{
+		data[:totLen:totLen],
+		func() {
+			backend.pool.Release(dataB)
+		}}, nil
 }
 
-// decodeMatrixSlow is a fallback when something went wrong with decodeMatrix (especially when data part is missing)
-func (backend *Backend) decodeMatrixSlow(frags [][]byte, piecesize int) (*DecodeData, error) {
-	fragLen := len(frags[0])
-	blockSize := piecesize + backend.headerSize
-	blockNr := fragLen / blockSize
-	if blockNr*blockSize != fragLen {
-		blockNr++
+// DecodeMatrix tries to reconstruct the data fragments and returns the linearized data.
+func (backend *Backend) DecodeMatrix(frags []ValidatedFragment, pieceSize int) (*DecodeData, error) {
+	fragRangeLen := len(frags[0])
+	chunkSize := pieceSize + backend.headerSize
+	chunkNr := fragRangeLen / chunkSize
+	if chunkNr*chunkSize != fragRangeLen {
+		chunkNr++
 	}
 
-	dataB, data := backend.pool.New(blockNr * piecesize * backend.K)
-
-	cellSize := piecesize + backend.headerSize
+	dataB, data := backend.pool.New(chunkNr * pieceSize * backend.K)
 
 	var totLen int64
 
-	for i := 0; i < blockNr; i++ {
+	for i := 0; i < chunkNr; i++ {
 		vect := make([][]byte, len(frags))
 		for j := 0; j < len(frags); j++ {
-			vect[j] = frags[j][i*cellSize : (i+1)*cellSize]
+			if len(frags[j]) != fragRangeLen {
+				return nil, errors.New("invalid fragment len")
+			}
+
+			vect[j] = frags[j][i*chunkSize : (i+1)*chunkSize]
 		}
 		subdata, err := backend.Decode(vect)
 		if err != nil {

--- a/backend.go
+++ b/backend.go
@@ -141,7 +141,7 @@ void encode_chunk_prepare(int desc,
     char *data,
     int datalen,
     int piecesize,
-	struct encode_chunk_context *ctx)
+    struct encode_chunk_context *ctx)
 {
     ctx->instance = liberasurecode_backend_instance_get_by_desc(desc);
     int i;
@@ -1160,33 +1160,31 @@ func (backend *Backend) Reconstruct(frags [][]byte, fragIndex int) ([]byte, erro
 }
 
 // ReconstructMatrix is a really not optimized yet reconstruction of a frag containing subchunking
-func (backend *Backend) ReconstructMatrix(frags [][]byte, fragIndex int, chunksize int) (*DecodeData, error) {
+func (backend *Backend) ReconstructMatrix(frags [][]byte, fragIndex int, pieceSize int) (*DecodeData, error) {
 	var wg sync.WaitGroup
 	if len(frags) == 0 {
 		return nil, errors.New("reconstruction requires at least one fragment")
 	}
 
 	fragLen := len(frags[0])
-	blockSize := chunksize + backend.headerSize
-	blockNr := fragLen / blockSize
-	if blockNr*blockSize != fragLen {
-		blockNr++
+	chunkSize := pieceSize + backend.headerSize
+	chunkNr := fragLen / chunkSize
+	if chunkNr*chunkSize != fragLen {
+		chunkNr++
 	}
-	dlen := blockNr * blockSize
+	dlen := chunkNr * chunkSize
 	dataB, data := backend.pool.New(dlen)
-
-	cellSize := chunksize + backend.headerSize
 
 	var errCounter uint32
 	// TODO use goroutines here to leverage multicore computation
-	wg.Add(blockNr)
-	for i := 0; i < blockNr; i++ {
-		go func(blocknr int) {
+	wg.Add(chunkNr)
+	for i := 0; i < chunkNr; i++ {
+		go func(chunkIdx int) {
 			vect := make([][]byte, len(frags))
 			for j := 0; j < len(frags); j++ {
-				vect[j] = frags[j][blocknr*cellSize : (blocknr+1)*cellSize]
+				vect[j] = frags[j][chunkIdx*chunkSize : (chunkIdx+1)*chunkSize]
 			}
-			if err := backend.reconstruct(vect, fragIndex, data[blocknr*blockSize:]); err != nil {
+			if err := backend.reconstruct(vect, fragIndex, data[chunkIdx*chunkSize:]); err != nil {
 				atomic.AddUint32(&errCounter, 1)
 			}
 			wg.Done()

--- a/backend.go
+++ b/backend.go
@@ -939,7 +939,6 @@ func (backend *Backend) LinearizeMatrix(frags []ValidatedFragment, pieceSize int
 	   all tasks completed. */
 	runtime.KeepAlive(frags)
 
-	// if we got some issues, fallback on "slow" decoding
 	if errorNb != 0 {
 		// Release the previous buffer
 		backend.pool.Release(dataB)

--- a/backend.go
+++ b/backend.go
@@ -1243,17 +1243,17 @@ type FragmentInfo struct {
 
 // GetFragmentInfo is the wrapper of the C implementation
 func GetFragmentInfo(frag []byte) FragmentInfo {
-	header := *(*C.struct_fragment_header_s)(unsafe.Pointer(&frag[0]))
-	backendID := C.getBackendID(&header)
+	header := (*C.struct_fragment_header_s)(unsafe.Pointer(&frag[0]))
+	backendID := C.getBackendID(header)
 	return FragmentInfo{
 		Index:               int(header.meta.idx),
 		Size:                int(header.meta.size),
 		BackendMetadataSize: int(header.meta.frag_backend_metadata_size),
-		OrigDataSize:        uint64(C.getOrigDataSize(&header)),
+		OrigDataSize:        uint64(C.getOrigDataSize(header)),
 		BackendID:           backendID,
 		BackendName:         idToName(backendID),
-		BackendVersion:      makeVersion(C.getBackendVersion(&header)),
-		ErasureCodeVersion:  makeVersion(C.getECVersion(&header)),
-		IsValid:             C.is_invalid_fragment_header((*C.fragment_header_t)(&header)) == 0,
+		BackendVersion:      makeVersion(C.getBackendVersion(header)),
+		ErasureCodeVersion:  makeVersion(C.getECVersion(header)),
+		IsValid:             C.is_invalid_fragment_header((*C.fragment_header_t)(header)) == 0,
 	}
 }

--- a/backend.go
+++ b/backend.go
@@ -991,7 +991,7 @@ type RangeMatrix struct {
  * range.
  *
  * There are a few design choices that make the result not always obvious.
- * 		1. Each fragment range is always identical.
+ *      1. Each fragment range is always identical.
  *      2. When the requested range wraps around fragments all fragments
  *         are always queried.
  *
@@ -1022,7 +1022,7 @@ type RangeMatrix struct {
  * Perfect cases occur when the request span a single group (column):
  *
  *     p1 [- - - -]
- * 		  [-[*]- -]
+ *        [-[*]- -]
  *     .. [-[*]- -]
  *     p4 [-[*]- -]
  *

--- a/backend.go
+++ b/backend.go
@@ -1016,7 +1016,7 @@ type RangeMatrix struct {
  *      2. When the requested range wraps around fragments all fragments
  *         are always queried.
  *
- * (1) is currently necessary to avoid querying multiple time the same
+ * (1) is currently necessary to avoid querying multiple times the same
  * fragment in case of failures (to reconstruct the data). This prefer
  * performing the minimum amount of IO requests, instead of reading the minimum
  * amount of data. We could lift this constraint if the caller would stream

--- a/backend.go
+++ b/backend.go
@@ -925,11 +925,19 @@ func (backend *Backend) LinearizeMatrix(frags []ValidatedFragment, pieceSize int
 			} else {
 				atomic.AddUint64(&totLen, uint64(outlen))
 			}
+
 			C.freeStrArray(cDataFrags)
 			wg.Done()
 		}(i)
 	}
 	wg.Wait()
+
+	/* Tasks above which call into C.linearize keep a pointer of each
+	   fragment to perform their computation. When all goroutines are in the
+	   ffi call, there is no outstanding reference to frags. This ensure
+	   that this array (and each frag that it references) do not get GC until
+	   all tasks completed. */
+	runtime.KeepAlive(frags)
 
 	// if we got some issues, fallback on "slow" decoding
 	if errorNb != 0 {

--- a/backend_test.go
+++ b/backend_test.go
@@ -2,11 +2,14 @@ package erasurecode
 
 import (
 	"bytes"
+	cryptorand "crypto/rand"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
+	"testing/quick"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -559,7 +562,7 @@ var decodeTests = []decodeTest{
 	{maxBuffer * 2, Params{Name: "isa_l_rs_vand", K: 2, M: 1, MaxBlockSize: maxBuffer / 2}},
 }
 
-func BenchmarkDecodeM(b *testing.B) {
+func BenchmarkLinearizeM(b *testing.B) {
 	for _, test := range decodeTests {
 		b.Run(test.String(), func(b *testing.B) {
 			backend, err := InitBackend(test.p)
@@ -578,7 +581,7 @@ func BenchmarkDecodeM(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				decoded, err := backend.DecodeMatrix(encoded.Data, DefaultChunkSize)
+				decoded, err := backend.LinearizeMatrix(encoded.Data, DefaultChunkSize)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -594,7 +597,7 @@ func BenchmarkDecodeM(b *testing.B) {
 	}
 }
 
-func BenchmarkDecodeMissingM(b *testing.B) {
+func BenchmarkDecodeM(b *testing.B) {
 	for _, test := range decodeTests {
 		b.Run(test.String(), func(b *testing.B) {
 			backend, err := InitBackend(test.p)
@@ -687,34 +690,6 @@ func BenchmarkReconstructM(b *testing.B) {
 	}
 }
 
-func BenchmarkDecodeMSlow(b *testing.B) {
-	for _, test := range decodeTests {
-		b.Run(test.String(), func(b *testing.B) {
-			backend, err := InitBackend(test.p)
-			if err != nil {
-				b.Fatal("cannot create backend", err)
-			}
-
-			buf := bytes.Repeat([]byte("A"), test.size)
-			encoded, err := backend.EncodeMatrix(buf, DefaultChunkSize)
-
-			if err != nil {
-				b.Fatal(err)
-			}
-			defer encoded.Free()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-
-				decoded, err := backend.decodeMatrixSlow(encoded.Data, DefaultChunkSize)
-				if err != nil {
-					b.Fatal(err)
-				}
-				decoded.Free()
-			}
-		})
-	}
-}
-
 func BenchmarkMatrix(b *testing.B) {
 	for _, dtest := range decodeTests {
 		blockSize := 32768
@@ -741,9 +716,10 @@ func BenchmarkMatrix(b *testing.B) {
 							b.Run("Decode", func(b *testing.B) {
 								encoded, _ := backend.EncodeMatrix(buf, blockSize)
 								defer encoded.Free()
+
 								b.ResetTimer()
 								for i := 0; i < b.N; i++ {
-									decoded, err := backend.DecodeMatrix(encoded.Data, blockSize)
+									decoded, err := backend.LinearizeMatrix(encoded.Data, blockSize)
 									if err != nil {
 										b.Fatal(err)
 									}
@@ -796,9 +772,7 @@ func TestEncodeM(t *testing.T) {
 	}
 
 	buf := make([]byte, 1024*1024)
-	for i := 0; i < len(buf); i++ {
-		buf[i] = byte('A' + i%26)
-	}
+	cryptorand.Read(buf)
 
 	testParams := []struct {
 		chunkUnit   int
@@ -821,14 +795,12 @@ func TestEncodeM(t *testing.T) {
 				t.Errorf("failed to encode %+v", err)
 			}
 
-			// Do the matrix decoding. It should work fastly because we have
-			// all data fragments. After, we check that our linearized buffer
-			// contains expected data
-			ddata, err := backend.DecodeMatrix(result.Data, p.chunkUnit)
+			// Check that our linearized buffer
+			// contains expected data when there is all data fragment.
+			ddata, err := backend.LinearizeMatrix(result.Data, p.chunkUnit)
 			assert.NoError(t, err)
-			if ok := checkData(ddata.Data); ok == false {
-				t.Errorf("bad matrix decoding")
-			}
+			assert.Equal(t, len(buf), len(ddata.Data), "data mismatch")
+			assert.Equalf(t, buf, ddata.Data, "data mismatch")
 
 			ddata.Free()
 
@@ -840,20 +812,9 @@ func TestEncodeM(t *testing.T) {
 			vect = append(vect, result.Data[4])
 			vect = append(vect, result.Data[5])
 
-			ddata2, _ := backend.decodeMatrixSlow(vect, p.chunkUnit)
-			if ok := checkData(ddata2.Data); ok == false {
-				t.Errorf("bad matrix repairing")
-			}
+			ddata2, _ := backend.DecodeMatrix(vect, p.chunkUnit)
+			assert.Equal(t, buf, ddata2.Data, "data mismatch")
 			ddata2.Free()
-
-			/*
-			 * now we will do the same but we should failed because the chunksize provided
-			 * to decode the data is not the same used by encode function
-			 */
-			_, err = backend.decodeMatrixSlow(result.Data, p.chunkUnit+1)
-			if err == nil {
-				t.Errorf("no error during decoding whereas bad params were provided")
-			}
 
 			result.Free()
 		})
@@ -861,48 +822,216 @@ func TestEncodeM(t *testing.T) {
 	backend.Close()
 }
 
-// checkData reads a buffer and check that we have a round robin sequence of [A-Z] characters
-func checkData(data []byte) bool {
-	for i := 0; i < len(data)-1; i++ {
-		if data[i] != 'Z' {
-			if data[i] != data[i+1]-1 {
-				return false
-			}
-		} else if data[i+1] != 'A' {
-			return false
-		}
-	}
-	return true
-}
+func TestLinearizeMatrix(t *testing.T) {
+	assert := assert.New(t)
 
-func TestMatrixBounds(t *testing.T) {
-	backend, err := InitBackend(Params{Name: "isa_l_rs_vand", K: 2, M: 1, W: 8, HD: 5})
+	pieceSize := DefaultChunkSize
+	k := 4
+	m := 1
 
+	backend, err := InitBackend(Params{Name: "isa_l_rs_vand", K: k, M: m, W: 8, HD: m})
 	if err != nil {
 		t.Fatalf("cannot init backend: (%v)", err)
 	}
 
-	testParams := []struct {
-		rangeStart    int
-		rangeEnd      int
-		chunkUnit     int
-		expectedStart int
-		expectedEnd   int
-	}{
-		{rangeStart: 1023999, rangeEnd: 1048575, chunkUnit: DefaultChunkSize, expectedStart: 492720, expectedEnd: 525568},
+	rangeValues := func(values []reflect.Value, rng *rand.Rand) {
+		dataSize := 1 + rng.Intn(7*1024*1024)
+
+		/* To avoid generating too many unintersting samples, this tests
+		   focuses on valid inputs. */
+		startIncl := rng.Intn(dataSize - 1)
+		endIncl := rng.Intn(dataSize - 1)
+		if endIncl < startIncl {
+			tmp := startIncl
+			startIncl = endIncl
+			endIncl = tmp
+		}
+
+		values[0] = reflect.ValueOf(startIncl)
+		values[1] = reflect.ValueOf(endIncl)
+		values[2] = reflect.ValueOf(dataSize)
 	}
 
-	for _, param := range testParams {
-		p := param
-		testName := fmt.Sprintf("TestEMatrixBounds-%d-%d", p.rangeStart, p.rangeEnd)
-		t.Run(testName, func(t *testing.T) {
-			rmatrix := backend.GetRangeMatrix(p.rangeStart, p.rangeEnd, p.chunkUnit, DefaultFragSize)
+	checkRange := func(startIncl, endIncl, dataSize int) bool {
+		t.Logf("TestLinearizeMatrix check %d-%d-%d", startIncl, endIncl, dataSize)
 
-			if rmatrix.FragRangeStart != p.expectedStart || rmatrix.FragRangeEnd != p.expectedEnd {
-				t.Errorf("error : %+v but got %+v", p, rmatrix)
+		data := make([]byte, dataSize)
+		cryptorand.Read(data)
+
+		encoded, err := backend.EncodeMatrix(data, DefaultChunkSize)
+		if err != nil {
+			t.Fatalf("failed to encode buffer: (%v)", err)
+		}
+		defer encoded.Free()
+
+		fragSize := len(encoded.Data[0])
+		rangeM := backend.GetRangeMatrix(startIncl, endIncl, pieceSize, fragSize)
+		assert.NotNil(rangeM)
+
+		/* Decode the matrix as if it was requested and
+		   checks that the result matches the payload on the requested range. */
+		frags := make([][]byte, 0)
+		for i := 0; i < rangeM.FragCount; i += 1 {
+			fragIdx := (rangeM.FragFirstIncl + i) % k
+			buffer := encoded.Data[fragIdx][rangeM.InFragRangeStartIncl:rangeM.InFragRangeEndExcl]
+			frags = append(frags, buffer)
+		}
+
+		decoded, err := backend.LinearizeMatrix(frags, pieceSize)
+		assert.Nil(err)
+		defer decoded.Free()
+
+		expected := data[startIncl : endIncl+1]
+
+		linearizedRangeEndExcl := rangeM.LinearizedRangeStartIncl + (endIncl - startIncl) + 1
+		found := decoded.Data[rangeM.LinearizedRangeStartIncl:linearizedRangeEndExcl]
+		return bytes.Equal(expected, found)
+	}
+
+	config := quick.Config{
+		Values: rangeValues,
+	}
+
+	if err := quick.Check(checkRange, &config); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDecodeMatrix(t *testing.T) {
+	assert := assert.New(t)
+
+	pieceSize := DefaultChunkSize
+	k := 4
+	m := 1
+
+	backend, err := InitBackend(Params{Name: "isa_l_rs_vand", K: k, M: m, W: 8, HD: m})
+	if err != nil {
+		t.Fatalf("cannot init backend: (%v)", err)
+	}
+
+	rangeValues := func(values []reflect.Value, rng *rand.Rand) {
+		dataSize := 1 + rng.Intn(7*1024*1024)
+
+		startIncl := rng.Intn(dataSize - 1)
+		endIncl := rng.Intn(dataSize - 1)
+		if endIncl < startIncl {
+			tmp := startIncl
+			startIncl = endIncl
+			endIncl = tmp
+		}
+
+		failedFragIdx := rng.Intn(k + m)
+
+		values[0] = reflect.ValueOf(startIncl)
+		values[1] = reflect.ValueOf(endIncl)
+		values[2] = reflect.ValueOf(dataSize)
+		values[3] = reflect.ValueOf(failedFragIdx)
+	}
+
+	checkRange := func(startIncl, endIncl, dataSize int, failedFragIdx int) bool {
+		t.Logf("TestDecodeMatrix check %d-%d-%d-%d", startIncl, endIncl, dataSize, failedFragIdx)
+
+		data := make([]byte, dataSize)
+		cryptorand.Read(data)
+
+		encoded, err := backend.EncodeMatrix(data, DefaultChunkSize)
+		if err != nil {
+			t.Fatalf("failed to encode buffer: (%v)", err)
+		}
+		defer encoded.Free()
+
+		fragSize := len(encoded.Data[0])
+		rangeM := backend.GetRangeMatrix(startIncl, endIncl, pieceSize, fragSize)
+		assert.NotNil(rangeM)
+
+		/* Decode the matrix as if it was requested and
+		   checks that the result matches the payload on the requested range. */
+		frags := make([][]byte, 0)
+		for i := 0; i < (k + m); i += 1 {
+			fragIdx := i
+			if fragIdx == failedFragIdx {
+				continue
 			}
 
-		})
+			buffer := encoded.Data[fragIdx][rangeM.InFragRangeStartIncl:rangeM.InFragRangeEndExcl]
+			frags = append(frags, buffer)
+		}
+
+		decoded, err := backend.DecodeMatrix(frags, pieceSize)
+		assert.Nil(err)
+		defer decoded.Free()
+
+		expected := data[startIncl : endIncl+1]
+
+		decodedRangeEndExcl := rangeM.DecodedRangeStartIncl + (endIncl - startIncl) + 1
+		found := decoded.Data[rangeM.DecodedRangeStartIncl:decodedRangeEndExcl]
+		return bytes.Equal(expected, found)
+	}
+
+	config := quick.Config{
+		Values: rangeValues,
+	}
+
+	if err := quick.Check(checkRange, &config); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestValidateFragmentMatrix(t *testing.T) {
+	assert := assert.New(t)
+
+	pieceSize := DefaultChunkSize
+	k := 4
+	m := 1
+
+	backend, err := InitBackend(Params{Name: "isa_l_rs_vand", K: k, M: m, W: 8, HD: m})
+	if err != nil {
+		t.Fatalf("cannot init backend: (%v)", err)
+	}
+
+	dataSize := 7 * 1024 * 1024
+	data := make([]byte, dataSize)
+	cryptorand.Read(data)
+
+	encoded, err := backend.EncodeMatrix(data, DefaultChunkSize)
+	if err != nil {
+		t.Fatalf("failed to encode buffer: (%v)", err)
+	}
+	defer encoded.Free()
+
+	fragSize := len(encoded.Data[0])
+	for i := 0; i < len(encoded.Data); i += 1 {
+		rangeMatrix := backend.GetRangeMatrix(0, dataSize-1, pieceSize, fragSize)
+		assert.NotNil(rangeMatrix)
+
+		frag := encoded.Data[i][rangeMatrix.InFragRangeStartIncl:rangeMatrix.InFragRangeEndExcl]
+		valid := backend.ValidateFragmentMatrix(frag, pieceSize)
+		assert.True(valid)
+
+		chunkSize := pieceSize + backend.headerSize
+		offset := 0
+		for offset < len(frag) {
+			for altered := 0; altered < backend.headerSize; altered += 1 {
+				t.Logf("frag %d altered offset %d altered %d", i, offset, altered)
+				previous := frag[offset+altered]
+				frag[offset+altered] = previous + 1
+
+				valid := backend.ValidateFragmentMatrix(frag, pieceSize)
+
+				/* libec_version and padding not checked */
+				if altered >= 63 && altered < 67 {
+					assert.True(valid)
+				} else if altered >= 71 {
+					assert.True(valid)
+				} else {
+					assert.False(valid)
+				}
+
+				frag[offset+altered] = previous
+			}
+
+			offset += chunkSize
+		}
 	}
 }
 

--- a/backend_test.go
+++ b/backend_test.go
@@ -1181,3 +1181,64 @@ func TestEncodeDecodeMatrix(t *testing.T) {
 		}
 	}
 }
+
+func TestRangeMatrix(t *testing.T) {
+	// These are basic tests on the rangeMatrix. More complete tests on the
+	// actual values are performed by the random tests:
+	// TestDecodeMatrix and TestLinearizeMatrix.
+	backend, err := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
+	if err != nil {
+		t.Fatalf("cannot init backend: (%v)", err)
+	}
+
+	pieceSize := DefaultChunkSize
+	fragSize := DefaultFragSize
+
+	/* Invalid ranges */
+	rangeM := backend.GetRangeMatrix(0, -1, pieceSize, fragSize)
+	assert.Nil(t, rangeM)
+
+	rangeM = backend.GetRangeMatrix(0, 10*fragSize, pieceSize, fragSize)
+	assert.Nil(t, rangeM)
+
+	/* Range is aligned on groups. */
+	startIncl := 0
+	endIncl := 0
+	rangeM = backend.GetRangeMatrix(startIncl, endIncl, pieceSize, fragSize)
+	rangeM = backend.GetRangeMatrix(startIncl, endIncl, pieceSize, fragSize)
+	assert.Equal(t, rangeM.FragCount, 1)
+	assert.Equal(t, rangeM.FragFirstIncl, 0)
+	assert.Equal(t, rangeM.ReqStartIncl, startIncl)
+	assert.Equal(t, rangeM.ReqEndIncl, endIncl)
+	assert.Equal(t, rangeM.ReqEndIncl, endIncl)
+
+	expectedTotalRead := (backend.headerSize + pieceSize)
+	totalRead := rangeM.FragCount * (rangeM.InFragRangeEndExcl - rangeM.InFragRangeStartIncl)
+	assert.Equal(t, expectedTotalRead, totalRead)
+
+	/* Range spanning a single group */
+	startIncl = 0
+	endIncl = backend.K*pieceSize - 1
+	rangeM = backend.GetRangeMatrix(startIncl, endIncl, pieceSize, fragSize)
+	assert.Equal(t, rangeM.FragCount, backend.K)
+	assert.Equal(t, rangeM.FragFirstIncl, 0)
+	assert.Equal(t, rangeM.ReqStartIncl, startIncl)
+	assert.Equal(t, rangeM.ReqEndIncl, endIncl)
+
+	expectedTotalRead = backend.K * (backend.headerSize + pieceSize)
+	totalRead = rangeM.FragCount * (rangeM.InFragRangeEndExcl - rangeM.InFragRangeStartIncl)
+	assert.Equal(t, expectedTotalRead, totalRead)
+
+	/* Range spanning multiple groups, this fallback to read two full groups. */
+	startIncl = (backend.K - 1) * pieceSize
+	endIncl = backend.K * pieceSize
+	rangeM = backend.GetRangeMatrix(startIncl, endIncl, pieceSize, fragSize)
+	assert.Equal(t, rangeM.FragFirstIncl, 0)
+	assert.Equal(t, rangeM.FragCount, 4)
+	assert.Equal(t, rangeM.ReqStartIncl, startIncl)
+	assert.Equal(t, rangeM.ReqEndIncl, endIncl)
+
+	expectedTotalRead = 2 * backend.K * (backend.headerSize + pieceSize)
+	totalRead = rangeM.FragCount * (rangeM.InFragRangeEndExcl - rangeM.InFragRangeStartIncl)
+	assert.Equal(t, expectedTotalRead, totalRead)
+}


### PR DESCRIPTION
This update the API to have more fined grained control and to have more efficient get range that span a single group.

Random tests have been added for the read range cases. The old `Decode` has been split into more modular component.